### PR TITLE
Changing how prisma-fmt takes parameters

### DIFF
--- a/src/format.ts
+++ b/src/format.ts
@@ -6,7 +6,7 @@ export default async function format(
   text: string,
 ): Promise<string> {
   try {
-    return await exec(exec_path, ['-s', ident_width.toString()], text)
+    return await exec(exec_path, ['format', '-s', ident_width.toString()], text)
   } catch (errors) {
     console.warn(
       "prisma-fmt error'd during formatting. This was likely due to a syntax error. Please see linter output.",

--- a/src/lint.ts
+++ b/src/lint.ts
@@ -11,7 +11,7 @@ export default async function lint(
   text: string,
 ): Promise<LinterError[]> {
   try {
-    const result = await exec(exec_path, ['--lint', '--no_env_errors'], text)
+    const result = await exec(exec_path, ['lint', '--no-env-errors'], text)
     return JSON.parse(result)
   } catch (errors) {
     console.error("prisma-fmt error'd during linting.")


### PR DESCRIPTION
The changes done in https://github.com/prisma/prisma-engines/pull/549 requires us to release a new version of the vscode plugin.