### PR TITLE
feat(automate-release): commit the prisma_version

### DIFF
--- a/scripts/check-update.sh
+++ b/scripts/check-update.sh
@@ -11,6 +11,8 @@ echo "NPM_VERSION: $NPM_VERSION"
 if [ "$CURRENT_VERSION" != "$NPM_VERSION" ]; then
     echo "UPDATING to $NPM_VERSION"
     echo "$NPM_VERSION" > scripts/prisma_version
+    git add -A .
+    git commit -m "bump prisma_version to $NPM_VERSION"
     yarn run vsce:publish
 else
     echo "CURRENT_VERSION ($CURRENT_VERSION) and NPM_VERSION ($NPM_VERSION) are same"


### PR DESCRIPTION
`vsce publish` does not like uncommitted files in a git repo. Since we use the file `prisma_version` to track if we need to publish, this failed https://github.com/prisma/vscode/pull/58's first flight: https://github.com/prisma/vscode/runs/503208075

To get around this, we need to commit the file before running `vsce publish`. 

The consequence would be that we get 2 commits for each release. We can squash them into a single commit in a future PR but test the functionality of automated release itself as is for now. 