### PR TITLE
infra(gitattributes_file_handling_line_endings) 

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# Shell scripts
+*.sh eol=lf


### PR DESCRIPTION
closes #146 

To avoid problems in your diffs and in our scripts, we a .gitattributes file configures Git to properly handle line endings.
Shell scripts need to keep LF (even on Windows systems).