### PR TITLE
fix(CI): use $(..) instead of `..` in script file

### DIFF
--- a/scripts/bump.sh
+++ b/scripts/bump.sh
@@ -33,7 +33,7 @@ if [ "$CHANNEL" = "dev" ]; then
     jq ".version = \"$NEXT_EXTENSION_VERSION\" | \
         .name = \"prisma-insider\" | \
         .displayName = \"Prisma - Insider\" | \
-        .description = \"This is the Insider Build of the Prisma VSCode extension (only use it if you are also using the `dev` version of the CLI.\" | \
+        .description = \"This is the Insider Build of the Prisma VSCode extension (only use it if you are also using the $(dev) version of the CLI.\" | \
         .preview = true" \
         ./package.json > ./package.json.bk
 else


### PR DESCRIPTION
Using `..` in the description in package.json is not supported. 