### PR TITLE
fix(CI): remove undefined parameter in update script

### DIFF
--- a/scripts/bump.sh
+++ b/scripts/bump.sh
@@ -15,10 +15,8 @@ fi
 RELEASE_CHANNEL=$1
 echo "RELEASE_CHANNEL: $RELEASE_CHANNEL"
 
-echo "PRISMA_CHANNEL=$RELEASE_CHANNEL"
-
 OLD_SHA=$(jq ".prisma.version" ./package.json)
-SHA=$(npx -q -p @prisma/cli@"$PRISMA_CHANNEL" prisma --version | grep "Query Engine" | awk '{print $5}')
+SHA=$(npx -q -p @prisma/cli@"$RELEASE_CHANNEL" prisma --version | grep "Query Engine" | awk '{print $5}')
 
 NPM_VERSION=$(sh scripts/prisma-version.sh "$RELEASE_CHANNEL")
 echo "NPM_VERSION: $NPM_VERSION"


### PR DESCRIPTION
This was causing the e2e tests to fail becuase the Prisma version in package.json was not set.